### PR TITLE
feat: Redis pub/sub for horizontal scaling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,56 +5,96 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 Chatatui is a terminal-based real-time chat application built in Go. It consists of two components:
-- **Server**: WebSocket-based chat server with room support
+- **Server**: WebSocket-based chat server with room support, backed by PostgreSQL and Redis
 - **Client**: Terminal UI client using Bubble Tea
 
 ## Commands
 
 ```bash
-# Run the TUI client
+# Build then run the TUI client (reads dev-config.toml by default)
 mise run dev
 
-# Start the chat server (listens on :8080)
+# Build then run the chat server
 mise run dev serve
 
-# Build
+# Build only
 mise run build
 
 # Run with debug logging (creates debug.log)
 DEBUG=1 mise run dev
+
+# Run all tests
+go test ./...
+
+# Run tests for a single package
+go test ./internal/service/...
+
+# Lint
+golangci-lint run
 ```
 
 ## Architecture
 
-### Server (`internal/server/`)
-- **server.go**: HTTP server wrapper with graceful shutdown
-- **api/handler.go**: Chi router setup with middleware (Logger, Recoverer, Heartbeat)
-- **api/ws_handler.go**: WebSocket endpoint handler at `/ws/{roomID}`
-- **hub/**: Real-time messaging core
-  - `hub.go`: Manages all rooms, thread-safe room creation/lookup
-  - `room.go`: Manages clients within a room, handles message broadcasting
-  - `client.go`: WebSocket client with read/write pumps and send channel
+### Request flow
 
-### Client (`internal/client/`)
-- **ui/index.go**: Bubble Tea model (currently minimal scaffolding)
+```
+Client (TUI) → WebSocket /ws/{roomID}
+                   ↓
+           api.WSHandler
+                   ↓
+           hub.Hub  ←→  Broker (Redis pub/sub)
+                   ↓
+           hub.Room → hub.Client (writePump/readPump goroutines)
+```
+
+Messages flow through Redis so that multiple server instances share state. `hub.Room.Broadcast` publishes to Redis; `hub.Hub.CreateRoom` subscribes and calls `room.fanOut` for every incoming message.
+
+### Server (`internal/server/`)
+
+- **api/handler.go**: Routes + middleware wiring. All authenticated routes use `middleware.APIKeyAuth` then `RateLimiter.Middleware`. Interfaces consumed by the handler (`ChatService`, `RoomHub`, `UserStore`, `RoomStore`) are defined here — not in their implementation packages.
+- **api/ws_handler.go**: Accepts WebSocket, resolves room via `hub.GetOrCreateRoom`, creates a `hub.Client`, sends message history, then calls `client.Run`.
+- **hub/hub.go**: Thread-safe map of active `Room`s. `GetOrCreateRoom` is the safe entry point; `CreateRoom` errors on duplicates.
+- **hub/room.go**: Fan-out to connected clients. Activates a `BroadcastPool` (10 workers) once a room reaches 10 clients.
+- **hub/client.go**: `readPump` receives raw text, persists via `MessagePersister`, wraps in a `hub.Message` JSON envelope, and calls `room.Broadcast`. `writePump` drains the `send` channel.
+- **hub/broker.go**: `Broker` interface + `RedisBroker` implementation using Redis pub/sub. Channel key format: `room:<uuid>`.
+
+### Service layer (`internal/service/`)
+
+`ChatService` sits between the API and the repository. Its store interfaces (`RoomStore`, `MessageStore`) are defined in `service/service.go`; mocks live in `service/_mocks/`.
+
+### Client (`internal/client/ui/`)
+
+Bubble Tea model split across four files: `model.go` (types/state), `update.go` (Msg handlers), `view.go` (rendering), `commands.go` (Cmd factories). The model manages WebSocket lifecycle directly, including reconnect backoff and typing indicators with a TTL.
 
 ### Repository (`internal/repository/`)
-- **sqlite.go**: GORM-based SQLite connection
-- **room.go**, **user.go**, **message.go**: Database models (not yet integrated with hub)
 
-### CLI (`cmd/`)
-Uses Cobra for commands:
-- Root command runs the TUI client
-- `serve` subcommand starts the server
+GORM-based PostgreSQL. `NewPostgresDB` opens a connection and runs `AutoMigrate` on startup. `PostgresDB` exposes typed sub-repositories (`Users()`, `Rooms()`, `Messages()`).
 
-## Key Dependencies
+### Middleware (`internal/middleware/`)
 
-- **github.com/charmbracelet/bubbletea**: TUI framework
-- **github.com/go-chi/chi/v5**: HTTP router
-- **github.com/coder/websocket**: WebSocket library
-- **gorm.io/gorm** + **gorm.io/driver/sqlite**: ORM and database
-- **github.com/spf13/cobra** + **github.com/spf13/viper**: CLI and config
+- `auth.go`: API key auth via `Authorization: Bearer <key>` header; injects `*repository.User` into context.
+- `ratelimit.go`: Sliding-window rate limiter backed by Redis (uses `github.com/EwanGreer/cache`).
 
 ## Configuration
 
-Config file: `$HOME/.chatatui.toml` (TOML format, loaded via Viper)
+Config file: `$HOME/.chatatui.toml` or passed via `--config`. See `dev-config.toml` for a local example.
+
+Key fields under `[server]`: `addr`, `database_dsn`, `redis_url`, `message_history_limit`, `room_list_limit`, `rate_limit_requests`, `rate_limit_window_secs`.
+
+## Mocks
+
+Mocks are generated with [mockery](https://vektra.github.io/mockery/) and live in `_mocks/` subdirectories next to the package that defines the interface. Regenerate with:
+
+```bash
+mockery --all
+```
+
+## Key Dependencies
+
+- **github.com/charmbracelet/bubbletea** + **bubbles**: TUI framework
+- **github.com/go-chi/chi/v5**: HTTP router
+- **github.com/coder/websocket**: WebSocket library
+- **github.com/redis/go-redis/v9**: Redis client
+- **gorm.io/gorm** + **gorm.io/driver/postgres**: ORM
+- **github.com/spf13/cobra** + **github.com/spf13/viper**: CLI and config
+- **github.com/stretchr/testify**: Test assertions and mocks

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/EwanGreer/chatatui/internal/server/api"
 	"github.com/EwanGreer/chatatui/internal/server/hub"
 	"github.com/EwanGreer/chatatui/internal/service"
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
 )
 
@@ -45,8 +46,21 @@ var serveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		var broker hub.Broker
+		if cfg.RedisURL != "" {
+			opt, err := redis.ParseURL(cfg.RedisURL)
+			if err != nil {
+				slog.Error("invalid redis_url, falling back to local broker", "error", err)
+				broker = hub.NewLocalBroker()
+			} else {
+				broker = hub.NewRedisBroker(redis.NewClient(opt))
+			}
+		} else {
+			broker = hub.NewLocalBroker()
+		}
+
 		svc := service.NewChatService(database.Rooms(), database.Messages())
-		handler := api.NewHandler(hub.NewHub(), database.Users(), database.Users(), database.Rooms(), svc, cfg, rateLimiter)
+		handler := api.NewHandler(hub.NewHub(broker), database.Users(), database.Users(), database.Rooms(), svc, cfg, rateLimiter)
 		srv := server.NewChatServer(handler, cfg.Addr, database)
 
 		go func() {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,18 +46,16 @@ var serveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		var broker hub.Broker
-		if cfg.RedisURL != "" {
-			opt, err := redis.ParseURL(cfg.RedisURL)
-			if err != nil {
-				slog.Error("invalid redis_url, falling back to local broker", "error", err)
-				broker = hub.NewLocalBroker()
-			} else {
-				broker = hub.NewRedisBroker(redis.NewClient(opt))
-			}
-		} else {
-			broker = hub.NewLocalBroker()
+		if cfg.RedisURL == "" {
+			slog.Error("redis_url is required")
+			os.Exit(1)
 		}
+		opt, err := redis.ParseURL(cfg.RedisURL)
+		if err != nil {
+			slog.Error("invalid redis_url", "error", err)
+			os.Exit(1)
+		}
+		broker := hub.NewRedisBroker(redis.NewClient(opt))
 
 		svc := service.NewChatService(database.Rooms(), database.Messages())
 		handler := api.NewHandler(hub.NewHub(broker), database.Users(), database.Users(), database.Rooms(), svc, cfg, rateLimiter)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -57,9 +57,10 @@ var serveCmd = &cobra.Command{
 		}
 		broker := hub.NewRedisBroker(redis.NewClient(opt))
 
+		h := hub.NewHub(broker)
 		svc := service.NewChatService(database.Rooms(), database.Messages())
-		handler := api.NewHandler(hub.NewHub(broker), database.Users(), database.Users(), database.Rooms(), svc, cfg, rateLimiter)
-		srv := server.NewChatServer(handler, cfg.Addr, database)
+		handler := api.NewHandler(h, database.Users(), database.Users(), database.Rooms(), svc, cfg, rateLimiter)
+		srv := server.NewChatServer(handler, cfg.Addr, database, h.Shutdown)
 
 		go func() {
 			slog.Info("server started", "addr", cfg.Addr)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -57,10 +57,10 @@ var serveCmd = &cobra.Command{
 		}
 		broker := hub.NewRedisBroker(redis.NewClient(opt))
 
-		h := hub.NewHub(broker)
+		hb := hub.NewHub(broker)
 		svc := service.NewChatService(database.Rooms(), database.Messages())
-		handler := api.NewHandler(h, database.Users(), database.Users(), database.Rooms(), svc, cfg, rateLimiter)
-		srv := server.NewChatServer(handler, cfg.Addr, database, h.Shutdown)
+		handler := api.NewHandler(hb, database.Users(), database.Users(), database.Rooms(), svc, cfg, rateLimiter)
+		srv := server.NewChatServer(handler, cfg.Addr, hb.Shutdown)
 
 		go func() {
 			slog.Info("server started", "addr", cfg.Addr)

--- a/internal/client/ui/commands.go
+++ b/internal/client/ui/commands.go
@@ -149,7 +149,7 @@ func sendMessageCmd(conn *websocket.Conn, text string) tea.Cmd {
 
 func sendTypingCmd(conn *websocket.Conn) tea.Cmd {
 	return func() tea.Msg {
-		msg := &hub.WireMessage{Type: hub.MessageTypeTyping}
+		msg := &hub.Message{Type: hub.MessageTypeTyping}
 		data, err := msg.Marshal()
 		if err != nil {
 			return errMsg(err)

--- a/internal/server/api/handler.go
+++ b/internal/server/api/handler.go
@@ -19,9 +19,13 @@ type ChatService interface {
 	PersistMessage(content []byte, senderID, roomID uuid.UUID) (uuid.UUID, time.Time, error)
 }
 
+type RoomHub interface {
+	GetOrCreateRoom(uuid.UUID) (*hub.Room, error)
+	ActiveCount() int
+}
+
 type Handler struct {
 	Router          chi.Router
-	Hub             *hub.Hub
 	ChatService     ChatService
 	Config          config.ServerConfig
 	RateLimiter     *middleware.RateLimiter
@@ -31,16 +35,15 @@ type Handler struct {
 	roomsHandler    *RoomsHandler
 }
 
-func NewHandler(h *hub.Hub, users middleware.UserLookup, userStore UserStore, roomStore RoomStore, svc ChatService, cfg config.ServerConfig, rl *middleware.RateLimiter) *Handler {
+func NewHandler(h RoomHub, users middleware.UserLookup, userStore UserStore, roomStore RoomStore, svc ChatService, cfg config.ServerConfig, rl *middleware.RateLimiter) *Handler {
 	r := chi.NewRouter()
 	r.Use(chimw.Logger)
 	r.Use(chimw.Recoverer)
 	r.Use(chimw.Heartbeat("/up"))
 
 	return &Handler{
-		Router:          r,
-		Hub:             h,
-		ChatService:     svc,
+		Router:      r,
+		ChatService: svc,
 		Config:          cfg,
 		RateLimiter:     rl,
 		userLookup:      users,

--- a/internal/server/api/handler.go
+++ b/internal/server/api/handler.go
@@ -42,8 +42,8 @@ func NewHandler(h RoomHub, users middleware.UserLookup, userStore UserStore, roo
 	r.Use(chimw.Heartbeat("/up"))
 
 	return &Handler{
-		Router:      r,
-		ChatService: svc,
+		Router:          r,
+		ChatService:     svc,
 		Config:          cfg,
 		RateLimiter:     rl,
 		userLookup:      users,
@@ -57,7 +57,7 @@ func (h *Handler) Routes() chi.Router {
 	h.Router.Post("/register", h.registerHandler.Handle)
 
 	h.Router.Group(func(r chi.Router) {
-		r.Use(
+		r.Use( // TODO: standardise how these are passed
 			middleware.APIKeyAuth(h.userLookup),
 			h.RateLimiter.Middleware,
 		)

--- a/internal/server/api/ws_handler.go
+++ b/internal/server/api/ws_handler.go
@@ -65,7 +65,7 @@ func (h *WSHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = conn.CloseNow() }()
 
-	room, err := h.hub.EnsureActive(roomUUID)
+	room, err := h.hub.GetOrCreateRoom(roomUUID)
 	if err != nil {
 		_ = conn.Close(websocket.StatusInternalError, "failed to join room")
 		return

--- a/internal/server/api/ws_handler.go
+++ b/internal/server/api/ws_handler.go
@@ -65,13 +65,7 @@ func (h *WSHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = conn.CloseNow() }()
 
-	room, err := h.hub.GetRoom(roomUUID)
-	if errors.Is(err, hub.ErrRoomNotFound) {
-		room, err = h.hub.CreateRoom(roomUUID)
-		if errors.Is(err, hub.ErrRoomExists) {
-			room, err = h.hub.GetRoom(roomUUID)
-		}
-	}
+	room, err := h.hub.EnsureActive(roomUUID)
 	if err != nil {
 		_ = conn.Close(websocket.StatusInternalError, "failed to join room")
 		return

--- a/internal/server/api/ws_handler.go
+++ b/internal/server/api/ws_handler.go
@@ -15,12 +15,12 @@ import (
 )
 
 type WSHandler struct {
-	hub                 *hub.Hub
+	hub                 RoomHub
 	svc                 ChatService
 	messageHistoryLimit int
 }
 
-func NewWSHandler(h *hub.Hub, svc ChatService, messageHistoryLimit int) *WSHandler {
+func NewWSHandler(h RoomHub, svc ChatService, messageHistoryLimit int) *WSHandler {
 	go func() {
 		for {
 			time.Sleep(time.Second * 5)

--- a/internal/server/api/ws_handler.go
+++ b/internal/server/api/ws_handler.go
@@ -66,17 +66,15 @@ func (h *WSHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = conn.CloseNow() }()
 
 	room, err := h.hub.GetRoom(roomUUID)
-	if err != nil {
-		if !errors.Is(err, hub.ErrRoomNotFound) {
-			_ = conn.Close(websocket.StatusInternalError, "failed to join room")
-			return
-		}
-
+	if errors.Is(err, hub.ErrRoomNotFound) {
 		room, err = h.hub.CreateRoom(roomUUID)
-		if err != nil {
-			_ = conn.Close(websocket.StatusInternalError, "failed to join room")
-			return
+		if errors.Is(err, hub.ErrRoomExists) {
+			room, err = h.hub.GetRoom(roomUUID)
 		}
+	}
+	if err != nil {
+		_ = conn.Close(websocket.StatusInternalError, "failed to join room")
+		return
 	}
 
 	user := middleware.UserFromContext(r.Context())

--- a/internal/server/api/ws_handler.go
+++ b/internal/server/api/ws_handler.go
@@ -82,7 +82,7 @@ func (h *WSHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	h.sendHistory(client, roomInfo.ID)
 
-	client.Run(room, h.svc)
+	client.Run(room, h.svc) // blocking
 }
 
 func (h *WSHandler) sendHistory(client *hub.Client, roomID uuid.UUID) {
@@ -94,14 +94,14 @@ func (h *WSHandler) sendHistory(client *hub.Client, roomID uuid.UUID) {
 
 	// Send messages in chronological order (oldest first)
 	for i := len(messages) - 1; i >= 0; i-- {
-		wire := &hub.WireMessage{
+		msg := &hub.Message{
 			Type:      hub.MessageTypeChat,
 			ID:        messages[i].ID.String(),
 			Author:    messages[i].Author,
 			Content:   messages[i].Content,
 			Timestamp: messages[i].CreatedAt,
 		}
-		wireBytes, err := wire.Marshal()
+		wireBytes, err := msg.Marshal()
 		if err != nil {
 			slog.Error("failed to marshal history message", "error", err, "room_id", roomID)
 			continue

--- a/internal/server/api/ws_handler.go
+++ b/internal/server/api/ws_handler.go
@@ -24,7 +24,7 @@ func NewWSHandler(h *hub.Hub, svc ChatService, messageHistoryLimit int) *WSHandl
 	go func() {
 		for {
 			time.Sleep(time.Second * 5)
-			slog.Debug("hub status", "room_count", len(h.Rooms))
+			slog.Debug("hub status", "room_count", h.ActiveCount())
 		}
 	}()
 

--- a/internal/server/api/ws_handler_test.go
+++ b/internal/server/api/ws_handler_test.go
@@ -20,7 +20,7 @@ import (
 // shape, without starting the hub status goroutine.
 func newWSHandlerRouter(svc ChatService) http.Handler {
 	h := &WSHandler{
-		hub:                 hub.NewHub(),
+		hub:                 hub.NewHub(hub.NewLocalBroker()),
 		svc:                 svc,
 		messageHistoryLimit: 50,
 	}
@@ -40,7 +40,7 @@ func TestWSHandler_MissingRoomID(t *testing.T) {
 	svc := mocks.NewMockChatService(t)
 
 	// Register a route without the {roomID} segment so chi sets it to "".
-	h := &WSHandler{hub: hub.NewHub(), svc: svc, messageHistoryLimit: 50}
+	h := &WSHandler{hub: hub.NewHub(hub.NewLocalBroker()), svc: svc, messageHistoryLimit: 50}
 	r := chi.NewRouter()
 	r.Get("/ws/", h.Handle)
 

--- a/internal/server/api/ws_handler_test.go
+++ b/internal/server/api/ws_handler_test.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	mocks "github.com/EwanGreer/chatatui/internal/server/api/_mocks"
@@ -16,11 +18,51 @@ import (
 	"gorm.io/gorm"
 )
 
+type testBroker struct {
+	mu   sync.Mutex
+	subs map[uuid.UUID][]chan []byte
+}
+
+func newTestBroker() *testBroker {
+	return &testBroker{subs: make(map[uuid.UUID][]chan []byte)}
+}
+
+func (b *testBroker) Publish(_ context.Context, roomID uuid.UUID, msg []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.subs[roomID] {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	return nil
+}
+
+func (b *testBroker) Subscribe(_ context.Context, roomID uuid.UUID) (<-chan []byte, func(), error) {
+	ch := make(chan []byte, 64)
+	b.mu.Lock()
+	b.subs[roomID] = append(b.subs[roomID], ch)
+	b.mu.Unlock()
+	return ch, func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		chans := b.subs[roomID]
+		for i, c := range chans {
+			if c == ch {
+				b.subs[roomID] = append(chans[:i], chans[i+1:]...)
+				break
+			}
+		}
+		close(ch)
+	}, nil
+}
+
 // newWSHandlerRouter wires a WSHandler into a chi router matching the real route
 // shape, without starting the hub status goroutine.
 func newWSHandlerRouter(svc ChatService) http.Handler {
 	h := &WSHandler{
-		hub:                 hub.NewHub(hub.NewLocalBroker()),
+		hub:                 hub.NewHub(newTestBroker()),
 		svc:                 svc,
 		messageHistoryLimit: 50,
 	}
@@ -40,7 +82,7 @@ func TestWSHandler_MissingRoomID(t *testing.T) {
 	svc := mocks.NewMockChatService(t)
 
 	// Register a route without the {roomID} segment so chi sets it to "".
-	h := &WSHandler{hub: hub.NewHub(hub.NewLocalBroker()), svc: svc, messageHistoryLimit: 50}
+	h := &WSHandler{hub: hub.NewHub(newTestBroker()), svc: svc, messageHistoryLimit: 50}
 	r := chi.NewRouter()
 	r.Get("/ws/", h.Handle)
 

--- a/internal/server/hub/broker.go
+++ b/internal/server/hub/broker.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -58,52 +57,3 @@ func redisChannel(roomID uuid.UUID) string {
 	return "room:" + roomID.String()
 }
 
-// LocalBroker implements Broker using in-process pub/sub. Used for
-// single-instance mode and tests.
-type LocalBroker struct {
-	mu   sync.Mutex
-	subs map[uuid.UUID][]chan []byte
-}
-
-func NewLocalBroker() *LocalBroker {
-	return &LocalBroker{
-		subs: make(map[uuid.UUID][]chan []byte),
-	}
-}
-
-func (b *LocalBroker) Publish(_ context.Context, roomID uuid.UUID, msg []byte) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	for _, ch := range b.subs[roomID] {
-		select {
-		case ch <- msg:
-		default:
-		}
-	}
-	return nil
-}
-
-func (b *LocalBroker) Subscribe(_ context.Context, roomID uuid.UUID) (<-chan []byte, func(), error) {
-	ch := make(chan []byte, 64)
-
-	b.mu.Lock()
-	b.subs[roomID] = append(b.subs[roomID], ch)
-	b.mu.Unlock()
-
-	unsubscribe := func() {
-		b.mu.Lock()
-		defer b.mu.Unlock()
-
-		chans := b.subs[roomID]
-		for i, c := range chans {
-			if c == ch {
-				b.subs[roomID] = append(chans[:i], chans[i+1:]...)
-				break
-			}
-		}
-		close(ch)
-	}
-
-	return ch, unsubscribe, nil
-}

--- a/internal/server/hub/broker.go
+++ b/internal/server/hub/broker.go
@@ -1,0 +1,109 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+type Broker interface {
+	Publish(ctx context.Context, roomID uuid.UUID, msg []byte) error
+	Subscribe(ctx context.Context, roomID uuid.UUID) (<-chan []byte, func(), error)
+}
+
+// RedisBroker implements Broker using Redis pub/sub.
+type RedisBroker struct {
+	client *redis.Client
+}
+
+func NewRedisBroker(client *redis.Client) *RedisBroker {
+	return &RedisBroker{client: client}
+}
+
+func (b *RedisBroker) Publish(ctx context.Context, roomID uuid.UUID, msg []byte) error {
+	return b.client.Publish(ctx, redisChannel(roomID), msg).Err()
+}
+
+func (b *RedisBroker) Subscribe(ctx context.Context, roomID uuid.UUID) (<-chan []byte, func(), error) {
+	pubsub := b.client.Subscribe(ctx, redisChannel(roomID))
+
+	if _, err := pubsub.Receive(ctx); err != nil {
+		_ = pubsub.Close()
+		return nil, nil, fmt.Errorf("redis subscribe: %w", err)
+	}
+
+	ch := make(chan []byte, 64)
+
+	go func() {
+		defer close(ch)
+		for msg := range pubsub.Channel() {
+			select {
+			case ch <- []byte(msg.Payload):
+			default:
+			}
+		}
+	}()
+
+	unsubscribe := func() {
+		_ = pubsub.Close()
+	}
+
+	return ch, unsubscribe, nil
+}
+
+func redisChannel(roomID uuid.UUID) string {
+	return "room:" + roomID.String()
+}
+
+// LocalBroker implements Broker using in-process pub/sub. Used for
+// single-instance mode and tests.
+type LocalBroker struct {
+	mu   sync.Mutex
+	subs map[uuid.UUID][]chan []byte
+}
+
+func NewLocalBroker() *LocalBroker {
+	return &LocalBroker{
+		subs: make(map[uuid.UUID][]chan []byte),
+	}
+}
+
+func (b *LocalBroker) Publish(_ context.Context, roomID uuid.UUID, msg []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, ch := range b.subs[roomID] {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	return nil
+}
+
+func (b *LocalBroker) Subscribe(_ context.Context, roomID uuid.UUID) (<-chan []byte, func(), error) {
+	ch := make(chan []byte, 64)
+
+	b.mu.Lock()
+	b.subs[roomID] = append(b.subs[roomID], ch)
+	b.mu.Unlock()
+
+	unsubscribe := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+
+		chans := b.subs[roomID]
+		for i, c := range chans {
+			if c == ch {
+				b.subs[roomID] = append(chans[:i], chans[i+1:]...)
+				break
+			}
+		}
+		close(ch)
+	}
+
+	return ch, unsubscribe, nil
+}

--- a/internal/server/hub/client.go
+++ b/internal/server/hub/client.go
@@ -54,25 +54,25 @@ func (c *Client) readPump(ctx context.Context, room *Room, persister MessagePers
 		}
 
 		if len(data) > limits.MaxMessageLength {
-			errWire := &WireMessage{
+			errMsg := &Message{
 				Type:      MessageTypeError,
 				Content:   fmt.Sprintf("message too long (max %d characters)", limits.MaxMessageLength),
 				Timestamp: time.Now(),
 			}
-			if errBytes, err := errWire.Marshal(); err == nil {
+			if errBytes, err := errMsg.Marshal(); err == nil {
 				c.Send(errBytes)
 			}
 			continue
 		}
 
-		var peek WireMessage
+		var peek Message
 		if json.Unmarshal(data, &peek) == nil && peek.Type == MessageTypeTyping {
-			typingWire := &WireMessage{
+			typingMsg := &Message{
 				Type:      MessageTypeTyping,
 				Author:    c.Username,
 				Timestamp: time.Now(),
 			}
-			typingBytes, err := typingWire.Marshal()
+			typingBytes, err := typingMsg.Marshal()
 			if err != nil {
 				slog.Error("failed to marshal typing event", "error", err, "user_id", c.UserID)
 				continue
@@ -86,7 +86,7 @@ func (c *Client) readPump(ctx context.Context, room *Room, persister MessagePers
 			slog.Error("failed to persist message", "error", err, "room_id", c.RoomID, "user_id", c.UserID)
 		}
 
-		wire := &WireMessage{
+		wire := &Message{
 			Type:    MessageTypeChat,
 			ID:      msgID.String(),
 			Author:  c.Username,

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -26,7 +26,7 @@ func NewHub(broker Broker) *Hub {
 	}
 }
 
-func (h *Hub) GetOrCreateRoom(roomUUID uuid.UUID) (*Room, error) {
+func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -56,10 +56,6 @@ func (h *Hub) GetOrCreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	}
 
 	return room, nil
-}
-
-func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
-	return h.GetOrCreateRoom(roomUUID)
 }
 
 func (h *Hub) GetRoom(roomUUID uuid.UUID) (*Room, error) {

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -67,7 +67,7 @@ func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	return room, nil
 }
 
-func (h *Hub) EnsureActive(roomUUID uuid.UUID) (*Room, error) {
+func (h *Hub) GetOrCreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	if room, err := h.GetRoom(roomUUID); err == nil {
 		return room, nil
 	}

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -1,7 +1,9 @@
 package hub
 
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"sync"
 
 	"github.com/google/uuid"
@@ -10,31 +12,59 @@ import (
 var ErrRoomNotFound = errors.New("room not found")
 
 type Hub struct {
-	Rooms map[uuid.UUID]*Room // TODO: this should be redis
-	mu    sync.RWMutex
+	Rooms  map[uuid.UUID]*Room
+	mu     sync.RWMutex
+	broker Broker
+	subs   map[uuid.UUID]func()
 }
 
-func NewHub() *Hub {
+func NewHub(broker Broker) *Hub {
 	return &Hub{
-		Rooms: make(map[uuid.UUID]*Room),
+		Rooms:  make(map[uuid.UUID]*Room),
+		broker: broker,
+		subs:   make(map[uuid.UUID]func()),
 	}
 }
 
-func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
+func (h *Hub) GetOrCreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	room := NewRoom()
-	room.ID = roomUUID
+	if room, ok := h.Rooms[roomUUID]; ok {
+		return room, nil
+	}
 
+	publish := func(ctx context.Context, msg []byte) error {
+		return h.broker.Publish(ctx, roomUUID, msg)
+	}
+
+	room := NewRoom(publish)
+	room.ID = roomUUID
 	h.Rooms[roomUUID] = room
+
+	ch, unsub, err := h.broker.Subscribe(context.Background(), roomUUID)
+	if err != nil {
+		slog.Error("broker subscribe failed", "room_id", roomUUID, "error", err)
+		h.subs[roomUUID] = func() {}
+	} else {
+		h.subs[roomUUID] = unsub
+		go func() {
+			for msg := range ch {
+				room.fanOut(msg)
+			}
+		}()
+	}
 
 	return room, nil
 }
 
+func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
+	return h.GetOrCreateRoom(roomUUID)
+}
+
 func (h *Hub) GetRoom(roomUUID uuid.UUID) (*Room, error) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 
 	room, ok := h.Rooms[roomUUID]
 	if !ok {
@@ -53,13 +83,20 @@ func (h *Hub) Add(room *Room) {
 func (h *Hub) Remove(roomID uuid.UUID) {
 	h.mu.Lock()
 	room := h.Rooms[roomID]
+	if unsub, ok := h.subs[roomID]; ok {
+		unsub()
+		delete(h.subs, roomID)
+	}
 	delete(h.Rooms, roomID)
 	h.mu.Unlock()
 
-	// Clean up worker pool if room exists
 	if room != nil {
 		room.Shutdown()
 	}
+}
+
+func (h *Hub) Publish(ctx context.Context, roomID uuid.UUID, msg []byte) error {
+	return h.broker.Publish(ctx, roomID, msg)
 }
 
 func (h *Hub) Broadcast(msg []byte, sender *Client) {
@@ -71,10 +108,14 @@ func (h *Hub) Broadcast(msg []byte, sender *Client) {
 	}
 }
 
-// Shutdown gracefully shuts down all rooms and their worker pools
 func (h *Hub) Shutdown() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	for id, unsub := range h.subs {
+		unsub()
+		delete(h.subs, id)
+	}
 
 	for _, room := range h.Rooms {
 		room.Shutdown()

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -67,6 +67,38 @@ func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	return room, nil
 }
 
+func (h *Hub) EnsureActive(roomUUID uuid.UUID) (*Room, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if room, ok := h.active[roomUUID]; ok {
+		return room, nil
+	}
+
+	publish := func(ctx context.Context, msg []byte) error {
+		return h.broker.Publish(ctx, roomUUID, msg)
+	}
+
+	room := NewRoom(publish)
+	room.ID = roomUUID
+	h.active[roomUUID] = room
+
+	ch, unsub, err := h.broker.Subscribe(context.Background(), roomUUID)
+	if err != nil {
+		slog.Error("broker subscribe failed", "room_id", roomUUID, "error", err)
+		h.subs[roomUUID] = func() {}
+	} else {
+		h.subs[roomUUID] = unsub
+		go func() {
+			for msg := range ch {
+				room.fanOut(msg)
+			}
+		}()
+	}
+
+	return room, nil
+}
+
 func (h *Hub) GetRoom(roomUUID uuid.UUID) (*Room, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -68,35 +68,13 @@ func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
 }
 
 func (h *Hub) EnsureActive(roomUUID uuid.UUID) (*Room, error) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	if room, ok := h.active[roomUUID]; ok {
+	if room, err := h.GetRoom(roomUUID); err == nil {
 		return room, nil
 	}
-
-	publish := func(ctx context.Context, msg []byte) error {
-		return h.broker.Publish(ctx, roomUUID, msg)
+	if room, err := h.CreateRoom(roomUUID); !errors.Is(err, ErrRoomExists) {
+		return room, err
 	}
-
-	room := NewRoom(publish)
-	room.ID = roomUUID
-	h.active[roomUUID] = room
-
-	ch, unsub, err := h.broker.Subscribe(context.Background(), roomUUID)
-	if err != nil {
-		slog.Error("broker subscribe failed", "room_id", roomUUID, "error", err)
-		h.subs[roomUUID] = func() {}
-	} else {
-		h.subs[roomUUID] = unsub
-		go func() {
-			for msg := range ch {
-				room.fanOut(msg)
-			}
-		}()
-	}
-
-	return room, nil
+	return h.GetRoom(roomUUID)
 }
 
 func (h *Hub) GetRoom(roomUUID uuid.UUID) (*Room, error) {

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -9,7 +9,10 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrRoomNotFound = errors.New("room not found")
+var (
+	ErrRoomNotFound = errors.New("room not found")
+	ErrRoomExists   = errors.New("room already active")
+)
 
 type Hub struct {
 	active map[uuid.UUID]*Room
@@ -36,8 +39,8 @@ func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if room, ok := h.active[roomUUID]; ok {
-		return room, nil
+	if _, ok := h.active[roomUUID]; ok {
+		return nil, ErrRoomExists
 	}
 
 	publish := func(ctx context.Context, msg []byte) error {

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -12,7 +12,7 @@ import (
 var ErrRoomNotFound = errors.New("room not found")
 
 type Hub struct {
-	Rooms  map[uuid.UUID]*Room
+	active map[uuid.UUID]*Room
 	mu     sync.RWMutex
 	broker Broker
 	subs   map[uuid.UUID]func()
@@ -20,17 +20,23 @@ type Hub struct {
 
 func NewHub(broker Broker) *Hub {
 	return &Hub{
-		Rooms:  make(map[uuid.UUID]*Room),
+		active: make(map[uuid.UUID]*Room),
 		broker: broker,
 		subs:   make(map[uuid.UUID]func()),
 	}
+}
+
+func (h *Hub) ActiveCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.active)
 }
 
 func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if room, ok := h.Rooms[roomUUID]; ok {
+	if room, ok := h.active[roomUUID]; ok {
 		return room, nil
 	}
 
@@ -40,7 +46,7 @@ func (h *Hub) CreateRoom(roomUUID uuid.UUID) (*Room, error) {
 
 	room := NewRoom(publish)
 	room.ID = roomUUID
-	h.Rooms[roomUUID] = room
+	h.active[roomUUID] = room
 
 	ch, unsub, err := h.broker.Subscribe(context.Background(), roomUUID)
 	if err != nil {
@@ -62,7 +68,7 @@ func (h *Hub) GetRoom(roomUUID uuid.UUID) (*Room, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	room, ok := h.Rooms[roomUUID]
+	room, ok := h.active[roomUUID]
 	if !ok {
 		return nil, ErrRoomNotFound
 	}
@@ -72,18 +78,18 @@ func (h *Hub) GetRoom(roomUUID uuid.UUID) (*Room, error) {
 
 func (h *Hub) Add(room *Room) {
 	h.mu.Lock()
-	h.Rooms[room.ID] = room
+	h.active[room.ID] = room
 	h.mu.Unlock()
 }
 
 func (h *Hub) Remove(roomID uuid.UUID) {
 	h.mu.Lock()
-	room := h.Rooms[roomID]
+	room := h.active[roomID]
 	if unsub, ok := h.subs[roomID]; ok {
 		unsub()
 		delete(h.subs, roomID)
 	}
-	delete(h.Rooms, roomID)
+	delete(h.active, roomID)
 	h.mu.Unlock()
 
 	if room != nil {
@@ -99,7 +105,7 @@ func (h *Hub) Broadcast(msg []byte, sender *Client) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	for _, room := range h.Rooms {
+	for _, room := range h.active {
 		room.Broadcast(msg, sender)
 	}
 }
@@ -113,7 +119,7 @@ func (h *Hub) Shutdown() {
 		delete(h.subs, id)
 	}
 
-	for _, room := range h.Rooms {
+	for _, room := range h.active {
 		room.Shutdown()
 	}
 }

--- a/internal/server/hub/hub.go
+++ b/internal/server/hub/hub.go
@@ -114,15 +114,6 @@ func (h *Hub) Publish(ctx context.Context, roomID uuid.UUID, msg []byte) error {
 	return h.broker.Publish(ctx, roomID, msg)
 }
 
-func (h *Hub) Broadcast(msg []byte, sender *Client) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	for _, room := range h.active {
-		room.Broadcast(msg, sender)
-	}
-}
-
 func (h *Hub) Shutdown() {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/internal/server/hub/message.go
+++ b/internal/server/hub/message.go
@@ -18,7 +18,7 @@ func (m MessageType) String() string {
 	return string(m)
 }
 
-type WireMessage struct {
+type Message struct {
 	Type      MessageType `json:"type"`
 	ID        string      `json:"id"`
 	Author    string      `json:"author"`
@@ -26,6 +26,6 @@ type WireMessage struct {
 	Timestamp time.Time   `json:"timestamp"`
 }
 
-func (m *WireMessage) Marshal() ([]byte, error) {
+func (m *Message) Marshal() ([]byte, error) {
 	return json.Marshal(m)
 }

--- a/internal/server/hub/room.go
+++ b/internal/server/hub/room.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 
@@ -14,14 +15,16 @@ type Room struct {
 	broadcastPool *BroadcastPool
 	poolThreshold int
 	workerCount   int
+	publish       func(ctx context.Context, msg []byte) error
 }
 
-func NewRoom() *Room {
+func NewRoom(publish func(ctx context.Context, msg []byte) error) *Room {
 	return &Room{
 		ID:            uuid.New(),
 		clients:       make(map[*Client]bool),
 		poolThreshold: 10,
 		workerCount:   10,
+		publish:       publish,
 	}
 }
 
@@ -56,33 +59,29 @@ func (r *Room) Remove(c *Client) {
 	r.mu.Unlock()
 }
 
-func (r *Room) Broadcast(msg []byte, sender *Client) {
+func (r *Room) Broadcast(msg []byte, _ *Client) {
+	if err := r.publish(context.Background(), msg); err != nil {
+		slog.Error("broker publish failed", "room_id", r.ID, "error", err)
+	}
+}
+
+func (r *Room) fanOut(msg []byte) {
 	r.mu.RLock()
 	poolEnabled := r.broadcastPool != nil
 
+	clientSnapshot := make([]*Client, 0, len(r.clients))
+	for client := range r.clients {
+		clientSnapshot = append(clientSnapshot, client)
+	}
+	r.mu.RUnlock()
+
 	if !poolEnabled {
-		clientSnapshot := make([]*Client, 0, len(r.clients))
-		for client := range r.clients {
-			if client != sender {
-				clientSnapshot = append(clientSnapshot, client)
-			}
-		}
-		r.mu.RUnlock()
 		for _, client := range clientSnapshot {
 			client.SendRaw(msg)
 		}
 		return
 	}
 
-	clientSnapshot := make([]*Client, 0, len(r.clients))
-	for client := range r.clients {
-		if client != sender {
-			clientSnapshot = append(clientSnapshot, client)
-		}
-	}
-	r.mu.RUnlock()
-
-	// Submit to worker pool (non-blocking)
 	job := &broadcastJob{
 		message: msg,
 		clients: clientSnapshot,
@@ -90,7 +89,6 @@ func (r *Room) Broadcast(msg []byte, sender *Client) {
 	r.broadcastPool.Submit(job)
 }
 
-// Shutdown gracefully shuts down the room and its worker pool
 func (r *Room) Shutdown() {
 	if r.broadcastPool != nil {
 		r.broadcastPool.Shutdown()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,17 +9,19 @@ import (
 )
 
 type ChatServer struct {
-	handler *api.Handler
-	srv     *http.Server
-	addr    string
-	db      *repository.PostgresDB
+	handler    *api.Handler
+	srv        *http.Server
+	addr       string
+	db         *repository.PostgresDB
+	onShutdown func()
 }
 
-func NewChatServer(h *api.Handler, addr string, db *repository.PostgresDB) *ChatServer {
+func NewChatServer(h *api.Handler, addr string, db *repository.PostgresDB, onShutdown func()) *ChatServer {
 	return &ChatServer{
-		handler: h,
-		addr:    addr,
-		db:      db,
+		handler:    h,
+		addr:       addr,
+		db:         db,
+		onShutdown: onShutdown,
 	}
 }
 
@@ -33,8 +35,8 @@ func (cs *ChatServer) Start() error {
 }
 
 func (cs *ChatServer) Stop(ctx context.Context) error {
-	if cs.handler != nil && cs.handler.Hub != nil {
-		cs.handler.Hub.Shutdown()
+	if cs.onShutdown != nil {
+		cs.onShutdown()
 	}
 
 	if cs.srv != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/EwanGreer/chatatui/internal/repository"
 	"github.com/EwanGreer/chatatui/internal/server/api"
 )
 
@@ -12,15 +11,13 @@ type ChatServer struct {
 	handler    *api.Handler
 	srv        *http.Server
 	addr       string
-	db         *repository.PostgresDB
 	onShutdown func()
 }
 
-func NewChatServer(h *api.Handler, addr string, db *repository.PostgresDB, onShutdown func()) *ChatServer {
+func NewChatServer(h *api.Handler, addr string, onShutdown func()) *ChatServer {
 	return &ChatServer{
 		handler:    h,
 		addr:       addr,
-		db:         db,
 		onShutdown: onShutdown,
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a `Broker` interface (`hub/broker.go`) with a `RedisBroker` implementation backed by `go-redis/v9`
- `Hub` subscribes to a Redis channel per room on first client join and fans out incoming messages to local clients via `room.fanOut`
- `room.Broadcast` now publishes to Redis instead of writing directly to client channels — all instances subscribed to the room receive and deliver the message
- `serve` requires `redis_url` in config and exits on startup if missing or invalid
- Tests use an inline `testBroker` satisfying the `Broker` interface

## Test plan

- [ ] Start two server instances pointing at the same Redis, connect a client to each in the same room, verify messages appear on both sides
- [ ] Typing indicators appear cross-instance
- [ ] Server fails to start with a clear error when `redis_url` is unset
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)